### PR TITLE
文本框内容NAN修复完成

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,16 +47,16 @@
     const newNumber = +inp.val() + 1;
     setNumber(inp, newNumber);
   });
-  // 数量input监听
-  // $("input").change(function () {
-  //   const inp = $(this);
-  //   const value = $(this).val();
-  //   if (!value || value == 0) {
-  //     $(this).val(1);
-  //   }
-  //   const newvalue = +value;
-  //   setNumber(inp, newvalue);
-  // });
+  数量input监听;
+  $("input").change(function () {
+    const inp = $(this);
+    const value = $(this).val();
+    if (!value || value == 0) {
+      $(this).val(+1);
+    }
+    const newvalue = +value;
+    setNumber(inp, newvalue);
+  });
 
   // 价格计算
   function setNumber(inp, number) {


### PR DESCRIPTION
由于最开始文本框中的value值为string类型所以导致价格计算出现NAN，将文本框的初始值设为number类型之后问题解决